### PR TITLE
Modify the code for computing relative_position_index to fix the AssertionError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ output/*
 *.pth
 */__pycache__
 data/
+
+pretrained/

--- a/config/s3dis/s3dis_stratified_transformer.yaml
+++ b/config/s3dis/s3dis_stratified_transformer.yaml
@@ -1,6 +1,6 @@
 DATA:
   data_name: s3dis
-  data_root: # Fill in the pre-processed data path (which contains the .npy files)
+  data_root: dataset/stanford_indoor3d # Fill in the pre-processed data path (which contains the .npy files)
   test_area: 5
   classes: 13
   fea_dim: 6
@@ -81,6 +81,6 @@ TEST:
   test_gpu: [0]
   test_workers: 4
   batch_size_test: 4
-  model_path: # Fill the path of the trained .pth file model
-  save_folder: # Fill the path to store the .npy files for each scene
+  model_path: pretrained/s3dis_model_best.pth # Fill the path of the trained .pth file model
+  save_folder: output/test/s3dis/stratified # Fill the path to store the .npy files for each scene
   names_path: data/s3dis/s3dis_names.txt

--- a/lib/pointops2/src/aggregation/aggregation_cuda.cpp
+++ b/lib/pointops2/src/aggregation/aggregation_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "aggregation_cuda_kernel.h"

--- a/lib/pointops2/src/attention/attention_cuda.cpp
+++ b/lib/pointops2/src/attention/attention_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "attention_cuda_kernel.h"

--- a/lib/pointops2/src/attention_v2/attention_cuda_v2.cpp
+++ b/lib/pointops2/src/attention_v2/attention_cuda_v2.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "attention_cuda_kernel_v2.h"

--- a/lib/pointops2/src/grouping/grouping_cuda.cpp
+++ b/lib/pointops2/src/grouping/grouping_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "grouping_cuda_kernel.h"

--- a/lib/pointops2/src/interpolation/interpolation_cuda.cpp
+++ b/lib/pointops2/src/interpolation/interpolation_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "interpolation_cuda_kernel.h"

--- a/lib/pointops2/src/knnquery/knnquery_cuda.cpp
+++ b/lib/pointops2/src/knnquery/knnquery_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "knnquery_cuda_kernel.h"

--- a/lib/pointops2/src/rpe/relative_pos_encoding_cuda.cpp
+++ b/lib/pointops2/src/rpe/relative_pos_encoding_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "relative_pos_encoding_cuda_kernel.h"

--- a/lib/pointops2/src/rpe_v2/relative_pos_encoding_cuda_v2.cpp
+++ b/lib/pointops2/src/rpe_v2/relative_pos_encoding_cuda_v2.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "relative_pos_encoding_cuda_kernel_v2.h"

--- a/lib/pointops2/src/sampling/sampling_cuda.cpp
+++ b/lib/pointops2/src/sampling/sampling_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "sampling_cuda_kernel.h"

--- a/lib/pointops2/src/subtraction/subtraction_cuda.cpp
+++ b/lib/pointops2/src/subtraction/subtraction_cuda.cpp
@@ -1,5 +1,6 @@
 #include <vector>
-#include <THC/THC.h>
+// #include <THC/THC.h>
+#include <ATen/cuda/CUDAEvent.h>
 #include <torch/serialize/tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "subtraction_cuda_kernel.h"

--- a/model/stratified_transformer.py
+++ b/model/stratified_transformer.py
@@ -185,7 +185,14 @@ class WindowAttention(nn.Module):
         # # Position embedding
         relative_position = xyz[index_0] - xyz[index_1]
         relative_position = torch.round(relative_position * 100000) / 100000
-        relative_position_index = (relative_position + 2 * self.window_size - 0.0001) // self.quant_size
+
+        # the previous code for computing relative_position_index cannot guarantee the lower bound (0)
+        # relative_position_index = (relative_position + 2 * self.window_size - 0.0001) // self.quant_size
+        relative_position_index = (relative_position + 2 * self.window_size) // self.quant_size
+        low_bound, high_bound = 0, 2 * self.quant_grid_length - 1
+        relative_position_index[relative_position_index == low_bound-1] = low_bound
+        relative_position_index[relative_position_index == high_bound+1] = high_bound
+
         assert (relative_position_index >= 0).all()
         assert (relative_position_index <= 2*self.quant_grid_length - 1).all()
 


### PR DESCRIPTION
1. Remove "include THC.h" for PyTorch 1.10+. It is the same as [this pull request](https://github.com/dvlab-research/Stratified-Transformer/pull/62).
2. Modify the code for computing relative_position_index. As described in [this issue](https://github.com/dvlab-research/Stratified-Transformer/issues/77), the code 
&nbsp;&nbsp; `relative_position_index = (relative_position + 2 * self.window_size - 0.0001) // self.quant_size` 
can guarantee all the values of relative_position_index do not exceed the upper bound (63) but cannot ensure that any of them is less than the lower bound (0).
3. The test.py for evaluating the pre-trained model is successful.  